### PR TITLE
Fix: iOS 10+ requires config in project settings

### DIFF
--- a/CrossMetaTrade/ProjectSettings/ProjectSettings.asset
+++ b/CrossMetaTrade/ProjectSettings/ProjectSettings.asset
@@ -139,6 +139,7 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1
@@ -160,6 +161,7 @@ PlayerSettings:
   applicationIdentifier:
     Android: com.DefaultCompany.CrossMetaTrade
     Standalone: com.DefaultCompany.CrossMetaTrade
+    iPhone: com.DefaultCompany.CrossMetaTrade
   buildNumber:
     Standalone: 0
     iPhone: 0
@@ -564,8 +566,8 @@ PlayerSettings:
   logObjCUncaughtExceptions: 1
   enableCrashReportAPI: 0
   cameraUsageDescription: 
-  locationUsageDescription: 
-  microphoneUsageDescription: 
+  locationUsageDescription: voice chat
+  microphoneUsageDescription: Use Mic for voice chat
   bluetoothUsageDescription: 
   switchNMETAOverride: 
   switchNetLibKey: 


### PR DESCRIPTION
Cannot build for iOS 10+, because it requires the values of `locationUsageDescription` and `microphoneUsageDescription` in Project Settings. Fixed this by adding the corresponding description.

![image](https://user-images.githubusercontent.com/1193077/191329631-935aa784-b4d9-4da8-8b09-0e6d3f27ac14.png)
